### PR TITLE
feat: prediction integration with error handling

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+data/incidentes-viales-c5.csv filter=lfs diff=lfs merge=lfs -text

--- a/api/prediction.py
+++ b/api/prediction.py
@@ -1,2 +1,205 @@
+# Moved from /Models by @kevinwkt.
+import inspect
+import json
+import numpy as np
+import pandas as pd
 
-class Prediction():
+from sklearn.linear_model import LinearRegression
+from sklearn.metrics import r2_score
+
+
+class Prediction:
+    def __init__(self, df):
+        self.df = df
+
+    # Switch with dispatcher method.
+    def predict(self, model, column, value):
+        return getattr(self, model)(column, value)
+
+    # Linear LSR with ScikitLearn.
+    def sklearn_linear_LSR(self, column, value):
+
+        # HARDCODED Get average of numbers of accidents per month.
+        x = sorted(list(self.df[column].unique()))
+        month = self.df[column]
+        y = []
+
+        # HARDCODED to accept months for now.
+        for i in range(1, 13):
+            total = sum(1 for j in month if i == j)
+            # Divide between number of years.
+            y.append(int(total / 7))
+
+        # Make x bidimensional.
+        X = np.array(x).reshape((-1, 1))
+        Y = np.array(y)
+
+        # Generate model.
+        model = LinearRegression().fit(X, Y)
+
+        # Get r2 confidence.
+        r_sq = model.score(X, Y)
+
+        # Get prediction.
+        y_prediction = model.predict(X)
+
+        # Create response payload.
+        input_dict = {
+            "model": inspect.stack()[0][3],
+            "column": column,
+            "value": value,
+        }
+        output_dict = {
+            "y": y_prediction[int(value)],
+            "r_sq": r_sq,
+        }
+        response = self.create_response_payload(input_dict, output_dict)
+
+        # Convert into response json.
+        return json.dumps(response)
+
+    # Polynomial LSR without ScikitLearn.
+    def polynomial_LSR(self, column, value):
+        # HARDCODED Get average number of accidents per month.
+        x = sorted(list(self.df[column].unique()))
+        month = self.df[column]
+        y = []
+
+        # HARDCODED to accept months for now.
+        for i in range(1, 13):
+            total = sum(1 for j in month if i == j)
+            # Divide between nuber of years.
+            y.append(int(total / 7))
+
+        # Sum XY.
+        xy = [a * b for a, b in zip(x, y)]
+        sumXY = sum(xy)
+
+        # Sum X2.
+        x2 = [a * b for a, b in zip(x, x)]
+        sumX2 = sum(x2)
+
+        # Sum X3.
+        x3 = [a * b for a, b in zip(x2, x)]
+        sumX3 = sum(x3)
+
+        # Sum X4.
+        x4 = [a * b for a, b in zip(x3, x)]
+        sumX4 = sum(x4)
+
+        # Sum X5.
+        x5 = [a * b for a, b in zip(x4, x)]
+        sumX5 = sum(x5)
+
+        # Sum X5.
+        x6 = [a * b for a, b in zip(x5, x)]
+        sumX6 = sum(x6)
+
+        # Sum X2Y.
+        x2y = [a * b for a, b in zip(x2, y)]
+        sumX2Y = sum(x2y)
+
+        # Sum X3Y.
+        x3y = [a * b for a, b in zip(x3, y)]
+        sumX3Y = sum(x3y)
+
+        sumX = sum(x)
+        sumY = sum(y)
+
+        n = len(x)
+
+        # Convert to matrix.
+        coffMat = np.matrix(
+            [
+                [n, sumX, sumX2, sumX3],
+                [sumX, sumX2, sumX3, sumX4],
+                [sumX2, sumX3, sumX4, sumX5],
+                [sumX3, sumX4, sumX5, sumX6],
+            ]
+        )
+        RHS = np.array([sumY, sumXY, sumX2Y, sumX3Y])
+
+        # Get inverse matrix.
+        invCoffMat = np.linalg.inv(coffMat)
+
+        # Get dot product.
+        coff = np.array(np.dot(invCoffMat, RHS))
+        coff = np.squeeze(np.asarray(coff))
+        a0, a1, a2, a3 = coff
+
+        # Get prediction model.
+        X_ = np.linspace(np.min(x), np.max(x), n)
+        Y_ = a0 + a1 * X_ + a2 * (X_ ** 2) + a3 * (X_ ** 3)
+
+        # Create response payload.
+        input_dict = {
+            "model": inspect.stack()[0][3],
+            "column": column,
+            "value": value,
+        }
+        output_dict = {
+            "y": Y_[int(value)],
+            "r_sq": r2_score(y, Y_),
+        }
+        response = self.create_response_payload(input_dict, output_dict)
+
+        # Convert into response json.
+        return json.dumps(response)
+
+    # Linear LSR without ScikitLearn.
+    def linear_LSR(self, column, value):
+        # HARDCODED Get average number of accidents per month.
+        x = sorted(list(self.df[column].unique()))
+        month = self.df[column]
+        y = []
+
+        # HARDCODED to accept months for now.
+        for i in range(1, 13):
+            total = sum(1 for j in month if i == j)
+            # Divide between nuber of years.
+            y.append(int(total / 7))
+
+        # Sum XY.
+        xy = [a * b for a, b in zip(x, y)]
+        sumXY = sum(xy)
+
+        # Sum X2.
+        xx = [a * b for a, b in zip(x, x)]
+        sumXX = sum(xx)
+
+        sumX = sum(x)
+        sumY = sum(y)
+
+        n = len(x)
+
+        # Get gradiant.
+        a1 = (n * sumXY) - (sumX * sumY)
+        a1 = a1 / ((n * sumXX) - (sumX ** 2))
+
+        # Get 'c'.
+        a0 = np.mean(y) - a1 * np.mean(x)
+
+        # Get predictive model.
+        ind = np.linspace(np.min(x), np.max(x), 12)
+        dep = a0 + a1 * ind
+
+        # Create response payload.
+        input_dict = {
+            "model": inspect.stack()[0][3],
+            "column": column,
+            "value": value,
+        }
+        output_dict = {
+            "y": dep[int(value)],
+        }
+        response = self.create_response_payload(input_dict, output_dict)
+
+        # Convert into response json.
+        return json.dumps(response)
+
+    def create_response_payload(self, input_dict, output):
+        prediction_json = {}
+        prediction_json["model"] = input_dict["model"]
+        prediction_json["input"] = input_dict
+        prediction_json["prediction"] = output
+        return prediction_json

--- a/app.py
+++ b/app.py
@@ -5,10 +5,11 @@ import numpy as np
 
 # Relative imports
 from api.stats import Stats
+from api.prediction import Prediction
 
 app = Flask(__name__)
 
-df = pd.read_csv("data/incidentes-viales.csv")
+df = pd.read_csv("data/incidentes-viales-c5.csv")
 # data_df1 = data["fecha_creacion"]
 # data_df2 = data["incidente_c4"]
 # df = pd.DataFrame({"fecha": data_df1, "incidente": data_df2})
@@ -24,7 +25,7 @@ def data_table():
     global df
 
     return render_template(
-        "index.html", tables=[df.to_html(classes="data")], titles=df.columns.values
+        "index.html", tables=[df.to_html(classes="data")], titles=df.columns.value
     )
 
 
@@ -36,12 +37,44 @@ def data_json():
 
 @app.route("/ingest", methods=["POST"])
 def set_ingest():
+    # Basic json format validation.
     if not request.json:
         return "Invalid Input Error", 422
+
+    # Process incoming json ingest.
     try:
         process_ingest(request.json)
+        # Returns successful no content success.
         return "", 204
     except:
+        # Unhandled errors should be taken care of.
+        return "Internal Server Error", 500
+
+
+@app.route("/predict", methods=["GET"])
+def handle_prediction():
+    global df
+
+    try:
+        # Parse query params.
+        model = request.args.get("model", default=None, type=str)
+        column = request.args.get("column", default=None, type=str)
+        value = request.args.get("value", default=None, type=str)
+
+        # Instantiate prediction class.
+        predictions = Prediction(df)
+
+        # If all query params are found call the queried model with params.
+        if model and column and value:
+            return predictions.predict(model, column, value)
+
+        # Return 422 if model, column, and value were not provided.
+        return "Invalid Input Error", 422
+    except AttributeError:
+        # Handle if Prediction class did not find requested model.
+        return "Model Not Found Error", 403
+    except:
+        # Unhandled errors should be taken care of.
         return "Internal Server Error", 500
 
 
@@ -50,12 +83,17 @@ def set_ingest():
 def get_stats():
     global df
 
-    column = request.args.get("column", default="", type=str)
-    if column == "" or column not in df.columns:
+    # Parse query params.
+    column = request.args.get("column", default=None, type=str)
+
+    # Baisc input validation.
+    if column is None or column not in df.columns:
         return "Invalid Input Error", 422
 
+    # Return basic stats by queried column.
     try:
         currenct_df_stats = Stats(df)
         return currenct_df_stats.get_stats(column)
     except:
+        # Unhandled errors should be taken care of.
         return "Internal Server Error", 500

--- a/data/incidentes-viales-c5.csv
+++ b/data/incidentes-viales-c5.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0ade58d6eabb2878e2807d055a750d7d63ebd6ddbc0c0b583c4bd237b49725d0
+size 474505686

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 flask
 pandas
 numpy
+sklearn
+matplotlib


### PR DESCRIPTION
First, I changed the endpoint to receive 3 different query params: model, column and value.
"model" can be one of the following: ["linear_LSR", "sklearn_linear_LSR", "polynomial_LSR"].
Currently, "column" has to be "mes" and "value" has to be a number between [0,11].

The response payload is currently a json in the following format:
{
  "model": "linear_LSR",
  "input": {
    "model": "linear_LSR",
    "column": "mes",
    "value": "10"
  },
  "prediction": {
    "y": 15974.553613053613
  }
}

This is the curl command when running in local with port 5000:
curl --request GET \
  --url 'http://127.0.0.1:5000/predict?model=polynomial_LSR&column=mes&value=10'

Here is an example image of payload with response:
![image](https://user-images.githubusercontent.com/16668571/77888964-4e88c300-722a-11ea-8deb-833baf52186a.png)

We now also handle errors where "model" is not found:
![image](https://user-images.githubusercontent.com/16668571/77889001-5fd1cf80-722a-11ea-815b-8fccda8c4df3.png)


All other errors are 500 INTERNAL_SERVER_ERRORs...


